### PR TITLE
Login Problem

### DIFF
--- a/frontend/packages/local/aladin/src/Aladin.js
+++ b/frontend/packages/local/aladin/src/Aladin.js
@@ -333,20 +333,6 @@ Ext.define('aladin.Aladin', {
             alSurvey,
             token;
 
-        token = window.localStorage['token'];
-
-        if (token) {
-            var realSend = XMLHttpRequest.prototype.send;
-
-            XMLHttpRequest.prototype.send = function () {
-                this.setRequestHeader('Authorization', 'Basic a');
-                this.setRequestHeader('Token', token);
-
-                realSend.apply(this, arguments);
-            };
-
-        }
-
         newSurvey = Ext.Object.merge(empty, survey);
 
         alSurvey = aladin.createImageSurvey(

--- a/frontend/packages/local/common/src/token/GetToken.js
+++ b/frontend/packages/local/common/src/token/GetToken.js
@@ -12,7 +12,14 @@ Ext.define('common.token.GetToken', {
             },
             success: function (response) {
                 token = JSON.parse(response.responseText).token;
-                window.localStorage.setItem('token', token);
+                var realSend = XMLHttpRequest.prototype.send;
+
+                XMLHttpRequest.prototype.send = function () {
+                    this.setRequestHeader('Authorization', 'Basic a');
+                    this.setRequestHeader('Token', token);
+
+                    realSend.apply(this, arguments);
+                };
             },
             failure: function (response, opts) {}
         });


### PR DESCRIPTION
Este PR centraliza adicionar os header necessários

Ele está colocando os headers certo em todos os requests:

![screenshot 2017-09-12 23 49 46](https://user-images.githubusercontent.com/13886329/30357465-1c00085e-9815-11e7-969f-9d6a5232615c.png)

Mas o `Access-Control-Request-Headers` parece estar filtrando o authorization e o token:

![screenshot 2017-09-12 23 52 55](https://user-images.githubusercontent.com/13886329/30357543-88b06020-9815-11e7-9f37-09e89067470d.png)

Pra arrumar isso acredito que a linha abaixo resolva mas não testei porque não vou mudar coisas no apache até subir o https.

`Header add Access-Control-Allow-Headers "authorization, token, content-type"`

Acredito que arrumando isso deve dar certo...