### PR TITLE
Download Target List compatible with DESacces.

### DIFF
--- a/api/product/descutoutservice.py
+++ b/api/product/descutoutservice.py
@@ -159,16 +159,17 @@ class DesCutoutService:
                 data.update({"ysize": job.cjb_ysize})
 
             # Geração de Imagens Fits
+            # Enviar o parametro que indica para o DESaccess que não é para incluir os fits
+            # utilizados na geração das imagens coloridas, incluir somente a cores solicitadas no colors_fits.
+            # discard_fits_files (bool) Discard FITS files that are only created in order to produce requested RGB images.
+            # FITS files that are explicitly requested are retained.
             if job.cjb_make_fits:
                 data.update({
                     "make_fits": True,
-                    "colors_fits": job.cjb_fits_colors
+                    "colors_fits": job.cjb_fits_colors,
+                    "discard_fits_files": True
                 })
             else:
-                # Enviar o parametro que indica para o DESaccess que não é para incluir os fits
-                # utilizados na geração das imagens coloridas.
-                # discard_fits_files (bool) Discard FITS files that are only created in order to produce requested RGB images.
-                # FITS files that are explicitly requested are retained.
                 data.update({
                     "discard_fits_files": True
                 })

--- a/api/product/export.py
+++ b/api/product/export.py
@@ -28,7 +28,6 @@ class Export:
 
         self.exclude_columns = ['meta_reject', 'meta_reject_id', 'meta_rating', 'meta_rating_id']
 
-
     def create_export_dir(self, name):
         """
         Cria um diretorio onde vao ficar os aquivos gerados.
@@ -84,7 +83,6 @@ class Export:
         self.logger.info("Retrieving the columns for the headers")
         columns = list()
 
-
         for property in row:
             cname = str(property.lower().strip())
 
@@ -105,12 +103,13 @@ class Export:
 
         self.logger.info("Export table \"%s\" to csv" % table)
 
+        # TODO: Pode ser melhorado o processo usando Pandas.Dataframe.to_csv()
         name = ("%s.csv" % table)
 
         filename = os.path.join(export_dir, name)
         self.logger.debug("Filename: %s" % filename)
 
-        rows, count = self.get_catalog_objects(product_id, table, user_id, schema, database,  filters=filters)
+        rows, count = self.get_catalog_objects(product_id, table, user_id, schema, database, filters=filters)
 
         self.logger.debug("Row Count: %s" % count)
 
@@ -154,6 +153,8 @@ class Export:
         """
 
         self.logger.info("Export table \"%s\" to csv" % table)
+
+        # TODO: Pode ser melhorado o processo usando Pandas.Dataframe.to_csv()
 
         name = ("%s.csv" % table)
 
@@ -241,7 +242,6 @@ class Export:
 
         self.logger.debug("User: %s" % user.username)
 
-
         # Recuperar o produto
         try:
             product = Product.objects.get(pk=int(product_id))
@@ -249,7 +249,6 @@ class Export:
 
         except Product.DoesNotExist as e:
             self.logger.error("Product matching query does not exist. Product Id: %s" % product_id)
-
 
         # colunas associadas ao produto
         associations = Association().get_associations_by_product_id(product_id=product_id)
@@ -282,17 +281,15 @@ class Export:
         :param path_destination: path absoluto do diretorio onde sera criado o zip.
         :param format: por enquanto apenas o formato .zip
         """
-        self.logger.info("Export cutouts of Job %s" % name)
+        self.logger.info("Export cutouts of Job [%s]" % name)
 
         self.logger.debug("Cutout Job path: %s" % path_origin)
-
-        origin_path = os.path.join(settings.DATA_DIR, path_origin.strip("/"))
 
         data_dir_tmp = settings.DATA_TMP_DIR
 
         destination_path = path_destination
 
-        self.logger.debug("Origin Path: %s" % origin_path)
+        self.logger.debug("Origin Path: %s" % path_origin)
         self.logger.debug("Destination Path: %s" % destination_path)
 
         not_images_extensions = list([".txt", ".csv", ".log"])
@@ -305,7 +302,7 @@ class Export:
             self.logger.debug("Zip File: %s" % filename)
 
             with zipfile.ZipFile(filename, 'w') as ziphandle:
-                for root, dirs, files in os.walk(origin_path):
+                for root, dirs, files in os.walk(path_origin):
                     for file in files:
                         origin_file = os.path.join(root, file)
                         fname, extension = os.path.splitext(origin_file)
@@ -436,4 +433,3 @@ class Export:
 
         else:
             self.logger.info("It was not possible to notify the user, for not having the email registered.")
-

--- a/api/product/tasks.py
+++ b/api/product/tasks.py
@@ -105,7 +105,8 @@ def export_target_by_filter(product_id, filetypes, user_id, filter_id=None, cuto
 
     logger = export.logger
 
-    logger.info("Starting Export Task for the product %s" % product_id)
+    logger.info("---------------------------------------------")
+    logger.info("Starting Export Task for the product [%s]" % product_id)
     logger.debug("User: %s" % user_id)
     logger.debug("Product: %s" % product_id)
     logger.debug("Filetypes: %s" % ", ".join(filetypes))
@@ -114,7 +115,6 @@ def export_target_by_filter(product_id, filetypes, user_id, filter_id=None, cuto
 
     # Criar o Diretorio de export
     try:
-
         # Recuperar o Model Product
         product = Product.objects.select_related().get(pk=int(product_id))
 
@@ -124,11 +124,7 @@ def export_target_by_filter(product_id, filetypes, user_id, filter_id=None, cuto
 
     user = User.objects.get(pk=int(user_id))
 
-    # Chords Task http://docs.celeryproject.org/en/latest/userguide/canvas.html#chords
-    header = list()
-
     try:
-
         # Notificação de inicio
         export.notify_user_export_start(user, product)
 
@@ -288,18 +284,9 @@ def export_cutoutjob(cutoutjob_id, export_dir):
 
     path = cutoutjob.cjb_cutouts_path
 
-    # Mantendo compatibilidade com Jobs anteriores ao path ser guardado
-    # TODO: Pode ser removido se todos os cutouts com o campo cjb_cutouts_path forem removidos
-    if path is None or path == "":
-        logger.warning(
-            "CutoutJob does not have the path field, the path will be generated using the result_file field.")
-        path = cutoutjob.cjb_results_file
-        path = os.path.dirname(path)
-        path = path.split(settings.DATA_DIR)[1]
-
     export.product_cutouts(
         name=cutoutjob.cjb_display_name,
-        path_origin=path.strip("/"),
+        path_origin=path,
         path_destination=export_dir
     )
 

--- a/frontend/target/app/view/objects/DownloadWindow.js
+++ b/frontend/target/app/view/objects/DownloadWindow.js
@@ -5,7 +5,7 @@ Ext.define('Target.view.objects.DownloadWindow', {
 
     title: 'Download',
     width: 300,
-    height: 400,
+    height: 300,
     modal: true,
     autoShow: true,
 
@@ -53,8 +53,8 @@ Ext.define('Target.view.objects.DownloadWindow', {
                                     xtype: 'checkboxgroup',
                                     columns: 1,
                                     items: [
-                                        {boxLabel: 'CSV', name: 'table_format', inputValue: 'csv', checked: true},
-                                        {boxLabel: 'FITS', name: 'table_format', inputValue: 'fits'}
+                                        { boxLabel: 'CSV', name: 'table_format', inputValue: 'csv', checked: true },
+                                        { boxLabel: 'FITS', name: 'table_format', inputValue: 'fits' }
                                         //{boxLabel: 'JSON', name: 'table_format', inputValue: 'json'}
                                     ]
                                 }
@@ -74,25 +74,6 @@ Ext.define('Target.view.objects.DownloadWindow', {
                             editable: false,
                             disabled: true
                         },
-                        {
-                            xtype: 'fieldset',
-                            title: 'Report',
-                            defaults: {
-                                anchor: '100%'
-                            },
-                            items: [
-                                {
-                                    xtype: 'checkboxgroup',
-                                    disabled: true,
-                                    columns: 1,
-                                    items: [
-                                        // {boxLabel: 'HTML', name: 'report_format', inputValue: 'html'},
-                                        {boxLabel: 'PDF', name: 'report_format', inputValue: 'pdf'}
-                                    ]
-                                }
-                            ],
-                            margin: '10 0 0 0'
-                        }
                     ]
                 }
             ],
@@ -150,7 +131,6 @@ Ext.define('Target.view.objects.DownloadWindow', {
             values,
             table_format = [],
             cutouts = null,
-            report_format = [],
             filter = null;
 
         if (form.isValid()) {
@@ -170,10 +150,6 @@ Ext.define('Target.view.objects.DownloadWindow', {
                 cutouts = values.cutouts;
             }
 
-            if (values.report_format) {
-                report_format = values.report_format;
-            }
-
             if (filter_id > 0) {
                 filter = filter_id;
             }
@@ -186,12 +162,11 @@ Ext.define('Target.view.objects.DownloadWindow', {
                     'filetypes': table_format,
                     'cutout': cutouts,
                     'filter': filter
-                    //                    'report_format': report_format
                 },
                 success: function (response) {
                     me.onCancel();
                     Ext.MessageBox.alert('', 'The job will run in the background and you will be notified when it is finished.');
-                    Ext.GlobalEvents.fireEvent('eventregister','TargetViewer - download_catalogs');
+                    Ext.GlobalEvents.fireEvent('eventregister', 'TargetViewer - download_catalogs');
                 },
                 failure: function (response, opts) {
                     var msg = response.status + ' ' + response.statusText;

--- a/frontend/target/app/view/objects/DownloadWindow.js
+++ b/frontend/target/app/view/objects/DownloadWindow.js
@@ -64,8 +64,8 @@ Ext.define('Target.view.objects.DownloadWindow', {
                             xtype: 'combobox',
                             itemId: 'cmbCutoutJob',
                             name: 'cutouts',
-                            fieldLabel: 'Mosaic',
-                            emptyText: 'Choose Mosaic',
+                            fieldLabel: 'Cutout',
+                            emptyText: 'Choose Cutout',
                             displayField: 'cjb_display_name',
                             valueField: 'id',
                             store: {


### PR DESCRIPTION
A refactoring was done in the download function of the target viewer. this change is for the download to be compatible with a new version of DESaccess.
The fix was simple, just changing the paths that were added to the zip file.

How to test:
- Open Target Viewer
- Select a list
- Check if the list already has Cutouts, if you don't run a job.
- Click on the "Download" button, choose form options and click on "Download".
- A message will appear informing you that the Job will be executed in the background.
- An email will be sent informing you of the start of the process.
- Depending on the size of the list and the number of cutout files, the job may take some time.
- An email will be sent informing you at the end of the process with a link to download the .zip file

Within the zip it should contain:
- the Cutout Job files.
- A csv file, if it has been checked.
- A Fits + csv file if the fits option has been checked.

Test different combinations of content to be downloaded.
Test jobs of different sizes.
Test with different Cutouts.