### PR TITLE
Fixed Overlay Catalog

### DIFF
--- a/api/lib/CatalogDB.py
+++ b/api/lib/CatalogDB.py
@@ -98,9 +98,9 @@ class CatalogTable(CatalogDB):
                 property = self.ordering[1:].lower()
 
             if asc:
-                stm = stm.order_by(text(property))
+                stm = stm.order_by(property)
             else:
-                stm = stm.order_by(desc(text(property)))
+                stm = stm.order_by(desc(property))
 
         # Paginacao
         if self.limit:
@@ -369,7 +369,7 @@ class CatalogObjectsDBHelper(CatalogTable):
 
         base_filters = and_(*self.do_filter(self.table, filters))
 
-        if coordinates_filter:
+        if coordinates_filter is not None:
             stm = stm.where(and_(base_filters, coordinates_filter))
         else:
             stm = stm.where(base_filters)


### PR DESCRIPTION
Fixed an error that prevented when executing an overlay of catalogs, the condition that determines whether the filter by positions will be used was in problem.

How to test.
- Open Sky viewer
- Select any release
- Access one of the tiles
- Click on the "Overlay Catalog" button
- Select one of the catalogs (except Vizier)
- Perform the overlay.
- check if the query brings results.