### PR TITLE
Registration of public releases.

### DIFF
--- a/Docs/exemplo_importacao_coadd_object_dr2.json
+++ b/Docs/exemplo_importacao_coadd_object_dr2.json
@@ -1,17 +1,17 @@
 {
     "products": [
         {
-            "display_name": "Y6A2 Coadd",
+            "display_name": "DR2",
             "fields": [],
             "releases": [
-                "y6a2_coadd"
+                "dr2"
             ],
-            "table": "Y6A2_COADD_OBJECT_SUMMARY",
+            "table": "DR2_MAIN_RC",
             "schema": "DES_ADMIN",
             "database": "dessci",
             "type": "catalog",
             "class": "coadd_objects",
-            "name": "y6a2_coadd",
+            "name": "dr2_coadd",
             "association": [
                 {
                     "ucd": "meta.id;meta.main",

--- a/Docs/exemplo_importacao_coadd_object_dr2.json
+++ b/Docs/exemplo_importacao_coadd_object_dr2.json
@@ -11,7 +11,7 @@
             "database": "dessci",
             "type": "catalog",
             "class": "coadd_objects",
-            "name": "dr2_coadd",
+            "name": "dr2",
             "association": [
                 {
                     "ucd": "meta.id;meta.main",
@@ -60,6 +60,6 @@
             ]
         }
     ],
-    "ticket": "GZY650",
+    "ticket": "VDB377",
     "register_username": "gverde"
 }

--- a/Docs/exemplo_importacao_coadd_object_y6a1.json
+++ b/Docs/exemplo_importacao_coadd_object_y6a1.json
@@ -1,17 +1,17 @@
 {
     "products": [
         {
-            "display_name": "Y6A2 Coadd",
+            "display_name": "Y6A1 Coadd",
             "fields": [],
             "releases": [
-                "y6a2_coadd"
+                "y6a1_coadd"
             ],
-            "table": "Y6A2_COADD_OBJECT_SUMMARY",
+            "table": "Y6A1_COADD_OBJECT_SUMMARY",
             "schema": "DES_ADMIN",
             "database": "dessci",
             "type": "catalog",
             "class": "coadd_objects",
-            "name": "y6a2_coadd",
+            "name": "y6a1_coadd",
             "association": [
                 {
                     "ucd": "meta.id;meta.main",

--- a/api/catalog/views.py
+++ b/api/catalog/views.py
@@ -377,7 +377,7 @@ class CatalogObjectsViewSet(ViewSet):
                             if release_set:
                                 release = release_set.release.rls_name
                                 # Se tiver release e ele for o Y3 subtrair 90 graus
-                                areleases = ['y3a1_coadd', 'y6a1_coadd', 'y6a2_coadd', 'dr1', ]
+                                areleases = ['y3a1_coadd', 'y6a1_coadd', 'y6a2_coadd', 'dr1', 'dr2']
                                 if release in areleases:
                                     t_image = 90 - t_image
 

--- a/api/coadd/management/commands/datadiscovery.py
+++ b/api/coadd/management/commands/datadiscovery.py
@@ -15,5 +15,12 @@ class Command(BaseCommand):
             help='Name of the release corresponding to the name the DES uses.',
         )
 
+        parser.add_argument(
+            '--image_host',
+            dest='image_host',
+            default='https://desportal.cosmology.illinois.edu',
+            help='Hostname where the iipserver server is. to devs leave the default value to use production images. for production environments inform the domain where the application is installed. with protocol and without / at the end. example: https://desportal.cosmology.illinois.edu',
+        )
+
     def handle(self, *args, **options):
         DataDiscovery(options).start()


### PR DESCRIPTION
The functions for registration public releases DR1 and DR2 have been included in the datadiscovery.


How to Test
`docker exec -it dri_backend_1 python manage.py datadiscovery --tag DR1`

`docker exec -it dri_backend_1 python manage.py datadiscovery --tag DR2`