### PR TITLE
Fixed Overlay DR2 Public

### DIFF
--- a/Docs/exemplo_importacao_coadd_object_dr2_public.json
+++ b/Docs/exemplo_importacao_coadd_object_dr2_public.json
@@ -1,0 +1,65 @@
+{
+    "products": [
+        {
+            "display_name": "DR2",
+            "fields": [],
+            "releases": [
+                "dr2"
+            ],
+            "table": "DR2_MAIN",
+            "schema": "DES_ADMIN",
+            "database": "desdr",
+            "type": "catalog",
+            "class": "coadd_objects",
+            "name": "dr2",
+            "association": [
+                {
+                    "ucd": "meta.id;meta.main",
+                    "property": "coadd_object_id"
+                },
+                {
+                    "ucd": "pos.eq.ra;meta.main",
+                    "property": "ra"
+                },
+                {
+                    "ucd": "pos.eq.dec;meta.main",
+                    "property": "dec"
+                },
+                {
+                    "ucd": "phys.size.smajAxis;instr.det;meta.main",
+                    "property": "a_image"
+                },
+                {
+                    "ucd": "phys.size.sminAxis;instr.det;meta.main",
+                    "property": "b_image"
+                },
+                {
+                    "ucd": "pos.posAng;instr.det;meta.main",
+                    "property": "theta_j2000"
+                },
+                {
+                    "ucd": "phot.mag;meta.main;em.opt.g",
+                    "property": "mag_auto_g"
+                },
+                {
+                    "ucd": "phot.mag;meta.main;em.opt.r",
+                    "property": "mag_auto_r"
+                },
+                {
+                    "ucd": "phot.mag;meta.main;em.opt.i",
+                    "property": "mag_auto_i"
+                },
+                {
+                    "ucd": "phot.mag;meta.main;em.opt.z",
+                    "property": "mag_auto_z"
+                },
+                {
+                    "ucd": "phot.mag;meta.main;em.opt.Y",
+                    "property": "mag_auto_y"
+                }
+            ]
+        }
+    ],
+    "ticket": "VDB377",
+    "register_username": "gverde"
+}

--- a/api/catalog/views.py
+++ b/api/catalog/views.py
@@ -281,8 +281,6 @@ class CatalogObjectsViewSet(ViewSet):
         # Criar uma lista de colunas baseda nas associacoes isso para limitar a query de nao usar *
         columns = Association().get_properties_associated(product_id)
 
-        print(columns)
-
         catalog_db = CatalogObjectsDBHelper(
             table=catalog.tbl_name,
             schema=catalog.tbl_schema,

--- a/api/product/association.py
+++ b/api/product/association.py
@@ -11,16 +11,12 @@ class Association:
         :return: list(["property1", "property2", ....])
         """
 
-        queryset = ProductContentAssociation.objects.select_related().filter(pca_product=product_id)
-        serializer = AssociationSerializer(queryset, many=True)
-        associations = serializer.data
         properties = list()
 
-        for associate in associations:
-            properties.append(associate.get('pcn_column_name').lower())
+        queryset = ProductContentAssociation.objects.select_related().filter(pca_product=product_id)
 
-        contents = ProductContent.objects.filter(pcn_product_id=product_id)
-        for pcontent in contents:
+        for associate in queryset:
+            pcontent = associate.pca_product_content
             if pcontent.pcn_ucd is not None and pcontent.pcn_column_name is not None and pcontent.pcn_column_name not in properties:
                 properties.append(pcontent.pcn_column_name.lower())
 
@@ -57,7 +53,6 @@ class Association:
                     associate.get('pcc_ucd'): associate.get('pcn_column_name').lower()
                 })
 
-
         return properties
 
     def get_association_list_by_product_id(self, product_id):
@@ -84,7 +79,6 @@ class Association:
                     "ucd": pcontent.pcn_ucd,
                     "property": pcontent.pcn_column_name.lower()
                 }))
-
 
         # TODO Modelo antigo pode ser removido futuramente.
         # colunas associadas ao produto utilizando o metodo antigo de associacao por classe


### PR DESCRIPTION
The function that returns the list of columns to be used in the Overlay query was changed, it had a bug that returned all columns. this change does not solve the original cause of the error, but prevents it from happening, since the column that returns a strange value is not in the query.

Steps to reproduce:
With the databases configured for the public environment.
perform an overlay of the DR2 Catalog.
or access this url via the API 
```
http://localhost/dri/api/catalogobjects/?_dc=1610638540549&page=1&offset=0&limit=5000&product=1794&coordinates=%5B%5B35.947216079119535%2C-9.725397291526518%5D%2C%5B35.934419920880465%2C-9.73275470847348%5D%5D

```