### PR TITLE
Query by position using Q3c

### DIFF
--- a/api/lib/CatalogDB.py
+++ b/api/lib/CatalogDB.py
@@ -266,69 +266,6 @@ class CatalogTable(CatalogDB):
 
         return conditions
 
-    def get_condition_square(self, lowerleft, upperright, property_ra, property_dec):
-
-        # Tratar RA > 360
-        llra = float(lowerleft[0])
-        lldec = float(lowerleft[1])
-
-        urra = float(upperright[0])
-        urdec = float(upperright[1])
-
-        if llra > 360:
-            llra = llra - 360
-
-        if urra > 360:
-            urra = urra - 360
-
-        # Verificar se o RA 0 esta entre llra e urra
-        if (llra < 0 and urra < 0) or (llra > 0 and urra > 0):
-            # RA 0 nao esta na area da consulta pode se usar o between simples
-
-            # BETWEEN llra and urra
-            raCondition = between(
-                Column(str(property_ra)),
-                literal_column(str(llra)),
-                literal_column(str(urra))
-            )
-
-        else:
-            # Area de interesse passa pelo RA 0 usar 2 between separando ate 0 e depois de 0
-
-            llralt0 = 360 - (llra * -1)
-
-            # Solucao para catalogos com RA 0 - 360
-            raLTZero = between(
-                Column(str(property_ra)),
-                literal_column(str(llralt0)),
-                literal_column("360")
-            )
-
-            raGTZero = between(
-                Column(str(property_ra)),
-                literal_column("0"),
-                literal_column(str(urra))
-            )
-
-            raCondition360 = or_(raLTZero, raGTZero).self_group()
-
-            # Solucao para catalogos com RA -180 a 180
-            raCondition180 = between(
-                Column(str(property_ra)),
-                literal_column(str(llra)),
-                literal_column(str(urra))
-            )
-
-            raCondition = or_(raCondition360, raCondition180).self_group()
-
-        decCondition = between(
-            Column(str(property_dec)),
-            literal_column(str(lldec)),
-            literal_column(str(urdec))
-        )
-
-        return and_(raCondition, decCondition).self_group()
-
     def count(self):
         with self.engine.connect() as con:
 
@@ -358,7 +295,7 @@ class CatalogObjectsDBHelper(CatalogTable):
         for condition in self.filters:
             if condition.get("op") == "coordinates":
 
-                coordinates_filter = self.get_condition_square(
+                coordinates_filter = self.database.get_condition_square(
                     condition.get("lowerleft"),
                     condition.get("upperright"),
                     condition.get("property_ra"),
@@ -583,7 +520,7 @@ class TargetObjectsDBHelper(CatalogTable):
 
                 elif condition.get("column") == 'coordinates':
 
-                    coordinate_filters = self.get_condition_square(
+                    coordinate_filters = self.database.get_condition_square(
                         condition.get("lowerleft"),
                         condition.get("upperright"),
                         condition.get("property_ra"),

--- a/api/lib/db_oracle.py
+++ b/api/lib/db_oracle.py
@@ -1,4 +1,7 @@
+from sqlalchemy import Column
 from sqlalchemy.dialects import oracle
+from sqlalchemy.sql import and_, or_
+from sqlalchemy.sql.expression import between, literal_column
 
 
 class DBOracle:
@@ -77,3 +80,66 @@ class DBOracle:
 
     def get_schema_name(self, schema):
         return schema.upper()
+
+    def get_condition_square(self, lowerleft, upperright, property_ra, property_dec):
+
+        # Tratar RA > 360
+        llra = float(lowerleft[0])
+        lldec = float(lowerleft[1])
+
+        urra = float(upperright[0])
+        urdec = float(upperright[1])
+
+        if llra > 360:
+            llra = llra - 360
+
+        if urra > 360:
+            urra = urra - 360
+
+        # Verificar se o RA 0 esta entre llra e urra
+        if (llra < 0 and urra < 0) or (llra > 0 and urra > 0):
+            # RA 0 nao esta na area da consulta pode se usar o between simples
+
+            # BETWEEN llra and urra
+            raCondition = between(
+                Column(str(property_ra)),
+                literal_column(str(llra)),
+                literal_column(str(urra))
+            )
+
+        else:
+            # Area de interesse passa pelo RA 0 usar 2 between separando ate 0 e depois de 0
+
+            llralt0 = 360 - (llra * -1)
+
+            # Solucao para catalogos com RA 0 - 360
+            raLTZero = between(
+                Column(str(property_ra)),
+                literal_column(str(llralt0)),
+                literal_column("360")
+            )
+
+            raGTZero = between(
+                Column(str(property_ra)),
+                literal_column("0"),
+                literal_column(str(urra))
+            )
+
+            raCondition360 = or_(raLTZero, raGTZero).self_group()
+
+            # Solucao para catalogos com RA -180 a 180
+            raCondition180 = between(
+                Column(str(property_ra)),
+                literal_column(str(llra)),
+                literal_column(str(urra))
+            )
+
+            raCondition = or_(raCondition360, raCondition180).self_group()
+
+        decCondition = between(
+            Column(str(property_dec)),
+            literal_column(str(lldec)),
+            literal_column(str(urdec))
+        )
+
+        return and_(raCondition, decCondition).self_group()

--- a/api/lib/db_postgresql.py
+++ b/api/lib/db_postgresql.py
@@ -1,4 +1,7 @@
+from sqlalchemy import Column
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import and_, or_, text
+from sqlalchemy.sql.expression import between, literal_column
 
 
 class DBPostgresql:
@@ -72,3 +75,26 @@ class DBPostgresql:
 
     def get_schema_name(self, schema):
         return schema
+
+    def get_condition_square(self, lowerleft, upperright, property_ra, property_dec):
+
+        raul = float(lowerleft[0])
+        decul = float(upperright[1])
+        ul = "{%s, %s}" % (raul, decul)
+
+        raur = float(upperright[0])
+        decur = float(upperright[1])
+        ur = "{%s, %s}" % (raur, decur)
+
+        ralr = float(upperright[0])
+        declr = float(lowerleft[1])
+        lr = "{%s, %s}" % (ralr, declr)
+
+        rall = float(lowerleft[0])
+        decll = float(lowerleft[1])
+        ll = "{%s, %s}" % (rall, decll)
+
+        # ul, ur, lr, ll
+        stm = "q3c_poly_query(ra, dec, '{ %s, %s, %s, %s}')" % (ul, ur, lr, ll)
+
+        return and_(text(stm)).self_group()


### PR DESCRIPTION
The CatalogDB class responsible for the queries used for Overlay in the visiomatic has been changed.
the method that generates the where clause by position was encapsulated in the specific classes DBOracle and DBPostgresql.

- When the registered catalog is in Oracle, a where clause is created using between.
- When the registered catalog is in Postgresql, a where clause is created using the q3c_poly_query function.

Behavior is the same from the point of view of the user, who does not know which bank the table is in.

Requirements:
- Have a catalog registered with Postgresql.
- The table must have the Q3C spatial indexes

How to Test:
- Open Sky Viewer and access one of the tiles via visiomatic.
- Overlay one of the catalogs registered in Postgresql.
