### PR TITLE
Fixed #1343 VizieR record not found

### DIFF
--- a/api/product/viziercds.py
+++ b/api/product/viziercds.py
@@ -8,6 +8,8 @@ from rest_framework.response import Response
 class VizierCDS:
     def get_available_catalogs(self):
 
+        # radius_unit: 'rs' para arcsec 'rm' para arcmin
+
         return list([
             # 2MASS
             dict({
@@ -29,6 +31,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # 2MASS 6X
             dict({
@@ -50,6 +54,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # SDSS Release 9
             dict({
@@ -71,6 +77,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # SDSS Release 12
             dict({
@@ -92,6 +100,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # PPMXL
             dict({
@@ -114,6 +124,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # # Abell clusters
             # dict({
@@ -135,6 +147,8 @@ class VizierCDS:
             #     "markable": False,
             #     "iconCls": "no-icon",
             #     "leaf": True,
+            # "radius_unit": 'rs',
+            # "radius": 1
             # }),
             # # NVSS
             # dict({
@@ -156,6 +170,8 @@ class VizierCDS:
             #     "markable": False,
             #     "iconCls": "no-icon",
             #     "leaf": True,
+            # "radius_unit": 'rs',
+            # "radius": 1
             # }),
             # # FIRST
             # dict({
@@ -177,6 +193,8 @@ class VizierCDS:
             #     "markable": False,
             #     "iconCls": "no-icon",
             #     "leaf": True,
+            # "radius_unit": 'rs',
+            # "radius": 1
             # }),
             # AllWISE
             dict({
@@ -198,6 +216,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # GALEX_AIS
             dict({
@@ -219,6 +239,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # GAIA_DR1
             dict({
@@ -240,6 +262,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # GAIA_DR2
             dict({
@@ -261,6 +285,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # GAIA_DR3
             dict({
@@ -282,6 +308,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # URAT1
             dict({
@@ -303,6 +331,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # PS1
             dict({
@@ -324,6 +354,8 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
             # HSC2
             dict({
@@ -345,8 +377,13 @@ class VizierCDS:
                 "markable": False,
                 "iconCls": "no-icon",
                 "leaf": True,
+                "radius_unit": 'rs',
+                "radius": 1
             }),
         ])
+
+    def get_catalog_by_source(self, source):
+        return next((item for item in self.get_available_catalogs() if item["cds_source"] == source), None)
 
     def get_objects(self, source, fieldnames, coordinates, bounds):
         """
@@ -408,6 +445,14 @@ class VizierCDS:
                 if not l.startswith("#") and not l.startswith("---"):
                     lines.append(l)
 
+            # Recuperar informação do catalogo
+            catalog = self.get_catalog_by_source(source)
+            radius_unit = 'rs'
+            radius = 1
+            if catalog is not None and 'radius' in catalog and 'radius_unit' in catalog:
+                radius = catalog['radius']
+                radius_unit = catalog['radius_unit']
+
             rows = list()
 
             reader = csv.DictReader(lines, fieldnames=fieldnames, delimiter=';')
@@ -419,7 +464,7 @@ class VizierCDS:
 
                 # Cria uma url para acessar o objeto direto no visier.
                 object_url = ("http://vizier.u-strasbg.fr/viz-bin/VizieR-5"
-                              "?-source=%s&-c=%s,%s,eq=J2000&-c.rs=0.01" % (source, ra, dec))
+                              "?-source=%s&-c=%s,%s,eq=J2000&-c.%s=%s" % (source, ra, dec, radius_unit, radius))
 
                 row.update({
                     "_meta_id": meta_id,

--- a/frontend/explorer/app/view/coadd/Coadd.js
+++ b/frontend/explorer/app/view/coadd/Coadd.js
@@ -44,7 +44,7 @@ Ext.define('Explorer.view.coadd.Coadd', {
                         pack: 'start',
                         align: 'stretch'
                     },
-                    items:[
+                    items: [
                         // Superior Esquerdo
                         {
                             xtype: 'coadd-form',
@@ -61,11 +61,11 @@ Ext.define('Explorer.view.coadd.Coadd', {
                                     text: 'NED',
                                     handler: 'onClickNed'
                                 },
-                                // {
-                                //     xtype: 'button',
-                                //     text: 'VizieR',
-                                //     handler: 'onClickVizier'
-                                // }
+                                {
+                                    xtype: 'button',
+                                    text: 'VizieR',
+                                    handler: 'onClickVizier'
+                                }
                             ]
                         },
                         // Inferior Esquerdo
@@ -95,7 +95,7 @@ Ext.define('Explorer.view.coadd.Coadd', {
                         {
                             xtype: 'panel',
                             // title: 'Superior',
-                            flex:1,
+                            flex: 1,
                             //height: 500,
                             layout: {
                                 type: 'hbox',

--- a/frontend/explorer/app/view/coadd/CoaddController.js
+++ b/frontend/explorer/app/view/coadd/CoaddController.js
@@ -450,11 +450,11 @@ Ext.define('Explorer.view.coadd.CoaddController', {
         var me = this,
             vm = me.getViewModel(),
             object = vm.get('object_data'),
-            radius = .01,
-            url; // Arcmin
+            radius = 1, // Arcsec
+            url;
 
         url = Ext.String.format(
-            "http://vizier.u-strasbg.fr/viz-bin/VizieR-5?-source=II/246&-c={0},{1},eq=J2000&-c.rs={2}",
+            "http://vizier.u-strasbg.fr/viz-bin/VizieR-5?-c={0},{1},eq=J2000&-c.rs={2}",
             object._meta_ra, object._meta_dec, radius)
 
         window.open(url, '_blank')


### PR DESCRIPTION
The units used in the search for the vizier were changed, now the default is the radius of 1 arcsec, this value can be customized individually by catalog in the register of external catalogs in the Vizier class.