### PR TITLE
The Tile ID search option has been removed from Sky Viewer

### DIFF
--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -79,7 +79,7 @@ services:
       - 3001:3000
 
   database:
-    image: ./compose/local/postgres
+    build: ./compose/local/postgres
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres

--- a/frontend/sky/app/view/main/Toolbar.js
+++ b/frontend/sky/app/view/main/Toolbar.js
@@ -35,9 +35,9 @@ Ext.define('Sky.view.main.Toolbar', {
                             // {
                             //     name:'HMS', text: 'RA, Dec (HMS)'
                             // }
-                            {
-                                name: 'tile', text: 'Tile ID'
-                            },
+                            // {
+                            //     name: 'tile', text: 'Tile ID'
+                            // },
                             {
                                 name: 'tli_tilename', text: 'Tile Name'
                             },


### PR DESCRIPTION
Fixed #1461 - The Tile ID search option has been removed from Sky Viewer.