### PR TITLE
Fixed error 500 in the target list when one of the values is NaN

### DIFF
--- a/api/catalog/views.py
+++ b/api/catalog/views.py
@@ -1,6 +1,6 @@
 import logging
 import math
-
+import numpy as np
 from django.conf import settings
 from django.db.models import Max
 from lib.CatalogDB import CatalogObjectsDBHelper, TargetObjectsDBHelper, CatalogDB
@@ -221,6 +221,11 @@ class TargetViewSet(ViewSet):
                         elif row.get(prop) < 0:
                             row.update({prop: "-Infinity"})
 
+                    # Fixed in Issue: https://github.com/linea-it/dri/issues/1489
+                    # Check if is NaN
+                    if math.isnan(float(row.get(prop))):
+                        row.update({prop: "nan"})
+
         return Response(dict({
             'count': count,
             'results': rows
@@ -376,6 +381,12 @@ class CatalogObjectsViewSet(ViewSet):
                             row.update({prop: "+Infinity"})
                         elif row.get(prop) < 0:
                             row.update({prop: "-Infinity"})
+
+                    # Fixed in Issue: https://github.com/linea-it/dri/issues/1489
+                    # Check if is NaN
+                    if math.isnan(float(row.get(prop))):
+                        row.update({prop: "nan"})
+
 
         return Response(dict({
             'count': count,


### PR DESCRIPTION
Iterates over each row of the result and over all columns, checks the type of the value to be for float.nan replaces it with string nan.
Fixed #1489 